### PR TITLE
Fix admin menu display after channel message

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -331,23 +331,7 @@ async def send_admin_panel(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 async def admin_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if not _is_admin(update.effective_user.id):
         return ConversationHandler.END
-    # Delete triggering message/callback to keep chat clean
-    try:
-        if update.callback_query and update.callback_query.message:
-            await update.callback_query.answer()
-            try:
-                await context.bot.delete_message(chat_id=update.callback_query.message.chat_id, message_id=update.callback_query.message.message_id)
-            except Exception:
-                pass
-        elif update.message:
-            try:
-                await context.bot.delete_message(chat_id=update.message.chat_id, message_id=update.message.message_id)
-            except Exception:
-                pass
-    except Exception:
-        pass
-
-    # Send only the requested notification
+    # Optional channel notice
     try:
         chat_id = update.effective_chat.id if update.effective_chat else (update.callback_query.message.chat_id if update.callback_query and update.callback_query.message else None)
         if chat_id is not None:
@@ -355,8 +339,8 @@ async def admin_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     except Exception:
         pass
 
-    # End admin flow to avoid sending any other admin messages
-    return ConversationHandler.END
+    # Show admin menu
+    return await send_admin_panel(update, context)
 
 
 # --- Order Review / Approval ---


### PR DESCRIPTION
Restore admin menu display for the `/admin` command, which was previously only sending a channel message.

The `admin_command` function was explicitly ending the conversation after sending an optional channel notification, preventing the `send_admin_panel` function from being called. This PR modifies the flow to call `send_admin_panel` after the notification, ensuring the admin menu is rendered as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-438c32a6-7c47-4b2d-b6d7-aed10fe2bee3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-438c32a6-7c47-4b2d-b6d7-aed10fe2bee3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

