### PR TITLE
Fix wallet charge request not sending

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -565,8 +565,8 @@ def build_application() -> Application:
     application.add_handler(CallbackQueryHandler(wallet_select_amount, pattern=r'^wallet_amt_'), group=3)
     application.add_handler(CallbackQueryHandler(wallet_upload_start_card, pattern=r'^wallet_upload_start_card$'), group=3)
     application.add_handler(CallbackQueryHandler(wallet_upload_start_crypto, pattern=r'^wallet_upload_start_crypto$'), group=3)
-    # Unified upload router handles both wallet and reseller
-    application.add_handler(MessageHandler(filters.PHOTO | filters.VOICE | filters.VIDEO | filters.AUDIO | filters.Document.ALL | filters.TEXT, composite_upload_router), group=2)
+    # Unified upload router handles both wallet and reseller (run early to avoid other catch-alls)
+    application.add_handler(MessageHandler(filters.PHOTO | filters.VOICE | filters.VIDEO | filters.AUDIO | filters.Document.ALL | filters.TEXT, composite_upload_router), group=0)
     application.add_handler(CallbackQueryHandler(wallet_verify_gateway, pattern=r'^wallet_verify_gateway$'), group=3)
 
     # Reseller flows


### PR DESCRIPTION
Prioritize `composite_upload_router` to prevent wallet/reseller upload messages from being intercepted by other handlers.

The previous setup caused photo/receipt messages, sent after initiating a wallet top-up or reseller action, to be caught by a more general `MessageHandler` in the same processing group. This prevented the specific wallet/reseller upload logic from executing, leading to no user confirmation or admin notification. Moving the `composite_upload_router` to group `0` ensures it's processed first.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb546037-bd9a-4462-a287-1873320cceae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb546037-bd9a-4462-a287-1873320cceae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

